### PR TITLE
Provide safer C APIs with buffer size and overflow checking

### DIFF
--- a/lib/ulid.h
+++ b/lib/ulid.h
@@ -19,36 +19,42 @@ typedef uint8_t ulid_t[16];
 struct ulid_ctx ulid_init(uint32_t seed);
 
 /**
- * Write a new 128-bit ULID in `dest`.
+ * Create a new 128-bit ULID in `dest`.
  *
- * If `ctx` pointer is null, the random number generator is re-seeded from
- * the system's clock.
+ * If the `ctx` pointer is null, the random number generator is re-seeded
+ * from the system's clock.
  *
- * The destination pointer `dest` must be a valid, non-null, pointer to
- * `ulid_t`.
+ * The destination `dest` must be a valid, non-null, pointer to `ulid_t`.
  */
 void ulid_new(struct ulid_ctx *ctx, ulid_t *dest);
 
 /**
- * Write a new ULID in `dest` using Crockford's Base32 alphabet.
+ * Write a new ULID to `dest` as a string.
  *
- * If `ctx` pointer is null, the random number generator is re-seeded from
- * the system's clock.
+ * Crockford's Base32 alphabet is used, and exactly 27 bytes are written,
+ * including the terminating null byte.
  *
- * The destination pointer `dest` must be a valid, non-null, pointer to
- * `char` buffer with at least length 26.
+ * The destination `dest` must be a valid, non-null, pointer to a `char`
+ * buffer with `size` bytes, and should have at least 27 bytes.
  *
- * No terminating null byte is written to the buffer.
+ * If the `ctx` pointer is null, the random number generator is re-seeded
+ * from the system's clock.
+ *
+ * Returns the number of characters printed (excluding the terminating null
+ * byte) on success, or a negative error code on failure.
  */
-void ulid_new_string(struct ulid_ctx *ctx, char *dest);
+int ulid_write_new(struct ulid_ctx *ctx, char *dest, size_t size);
 
 /**
- * Encode the 128-bit ULID pointed by `id` as a string in `dest`.
+ * Write the 128-bit ULID pointed by `id` to `dest` as a string.
  *
- * The destination pointer `dest` must be a valid, non-null, pointer to
- * `char` buffer with at least length 26.
+ * Crockford's Base32 alphabet is used, and exactly 27 bytes are written,
+ * including the terminating null byte.
  *
- * The Crockford's Base32 alphabet is used.  No terminating null byte is
- * written to the buffer.
+ * The destination `dest` must be a valid, non-null, pointer to a `char`
+ * buffer with `size` bytes, and should have at least 27 bytes.
+ *
+ * Returns the number of characters printed (excluding the terminating null
+ * byte) on success, or a negative error code on failure.
  */
-void ulid_encode(const ulid_t *id, char *dest);
+int ulid_write(const ulid_t *id, char *dest, size_t size);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 use core::fmt::{Display, Formatter, LowerHex, Result, UpperHex};
 use std::time::SystemTime;
 
+#[cfg(not(miri))]
+use libc;
+#[cfg(miri)]
+use libc_shim as libc;
+
 const ULID_LEN: usize = 26;
 mod base32 {
     use super::ULID_LEN;
@@ -338,11 +343,8 @@ mod that {
 ///
 /// Note: MIRIFLAGS="-Zmiri-disable-isolation" is needed for `SystemTime::now()`.
 #[cfg(miri)]
-mod libc {
-    use std::os::raw::{c_int, c_uint};
-
-    #[allow(non_camel_case_types)]
-    type time_t = i64;
+mod libc_shim {
+    pub use libc::{c_int, c_uint, time_t};
 
     pub unsafe fn rand() -> c_int {
         42


### PR DESCRIPTION
A few more changes to the C APIs, hopefully making them safer and (a bit) more natural to use.  Commit b7bfb81239b8 has the bulk of them, and a more in depth explanation.